### PR TITLE
Create PrometheusRule next to the cluster in the namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ The Operator comes as a pre-build container images: [quay.io/metalmatze/kube-coc
 The `operator/deployment/` contains a file that you can use to the deploy an instance of the Operator to deploy it to the `cockroachdb` namespace in your cluster. It'll start watching all `CockroachDB` Custom Resource Definitions (CRDs) in all namespaces by default.
 
 ```bash
-# Operator currently depends on the ServiceMonitor CRD
+# Operator currently depends on the ServiceMonitor & PrometheusRule CRD
 kubectl apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/kube-prometheus/master/manifests/setup/prometheus-operator-0prometheusruleCustomResourceDefinition.yaml
 # CockroachDB Custom Resource Definition
 kubectl apply -f https://raw.githubusercontent.com/metalmatze/kube-cockroachdb/master/operator/metalmatze.de_cockroachdbs.yaml
 # We'll deploy the operator to this namespace

--- a/examples/basic/basic.yaml
+++ b/examples/basic/basic.yaml
@@ -42,6 +42,110 @@ items:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: example
         app.kubernetes.io/name: cockroachdb-example
+- apiVersion: monitoring.coreos.com/v1
+  kind: PrometheusRule
+  metadata:
+    labels:
+      app.kubernetes.io/component: database
+      app.kubernetes.io/instance: example
+      app.kubernetes.io/name: cockroachdb-example
+      prometheus: k8s
+      role: alert-rules
+    name: cockroachdb-example
+    namespace: default
+  spec:
+    groups:
+    - name: cockroachdb
+      rules:
+      - alert: CockroachInstanceFlapping
+        annotations:
+          message: '{{ $labels.instance }} for cluster {{ $labels.cluster }} restarted {{ $value }} time(s) in 10m'
+        expr: |
+          resets(cockroachdb_sys_uptime{namespace="default",service="cockroachdb-example"}[10m]) > 5
+        for: 1m
+        labels:
+          severity: warning
+      - alert: CockroachLivenessMismatch
+        annotations:
+          message: Liveness mismatch for {{ $labels.instance }}
+        expr: |
+          (cockroachdb_liveness_livenodes{namespace="default",service="cockroachdb-example"})
+            !=
+          ignoring(instance) group_left() (count by(cluster, job) (up{namespace="default",service="cockroachdb-example"} == 1))
+        for: 5m
+        labels:
+          severity: warning
+      - alert: CockroachVersionMismatch
+        annotations:
+          message: Cluster {{ $labels.cluster }} running {{ $value }} different versions
+        expr: |
+          count by(cluster) (count_values by(tag, cluster) ("version", cockroachdb_build_timestamp{namespace="default",service="cockroachdb-example"})) > 1
+        for: 1h
+        labels:
+          severity: warning
+      - alert: CockroachStoreDiskLow
+        annotations:
+          message: Store {{ $labels.store }} on node {{ $labels.instance }} at {{ $value }} available disk fraction
+        expr: |
+          :cockroachdb_capacity_available:ratio{namespace="default",service="cockroachdb-example"} < 0.15
+        for: 30m
+        labels:
+          severity: critical
+      - alert: CockroachClusterDiskLow
+        annotations:
+          message: Cluster {{ $labels.cluster }} at {{ $value }} available disk fraction
+        expr: |
+          cluster:cockroachdb_capacity_available:ratio{namespace="default",service="cockroachdb-example"} < 0.2
+        for: 30m
+        labels:
+          severity: critical
+      - alert: CockroachUnavailableRanges
+        annotations:
+          message: Instance {{ $labels.instance }} has {{ $value }} unavailable ranges
+        expr: |
+          (sum by(instance, cluster) (cockroachdb_ranges_unavailable{namespace="default",service="cockroachdb-example"})) > 0
+        for: 10m
+        labels:
+          severity: critical
+      - alert: CockroachNoLeaseRanges
+        annotations:
+          message: Instance {{ $labels.instance }} has {{ $value }} ranges without leases
+        expr: |
+          (sum by(instance, cluster) (cockroachdb_replicas_leaders_not_leaseholders{namespace="default",service="cockroachdb-example"})) > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: CockroachHighOpenFDCount
+        annotations:
+          message: 'Too many open file descriptors on {{ $labels.instance }}: {{ $value }} fraction used'
+        expr: |
+          cockroachdb_sys_fd_open{namespace="default",service="cockroachdb-example"} / cockroachdb_sys_fd_softlimit{namespace="default",service="cockroachdb-example"} > 0.8
+        for: 10m
+        labels:
+          severity: warning
+    - name: cockroachdb.rules
+      rules:
+      - expr: |
+          sum without(store) (cockroachdb_capacity{namespace="default",service="cockroachdb-example"})
+        record: node:cockroachdb_capacity:sum
+      - expr: |
+          sum without(instance) (node:cockroachdb_capacity:sum{namespace="default",service="cockroachdb-example"})
+        record: cluster:cockroachdb_capacity:sum
+      - expr: |
+          sum without(store) (cockroachdb_capacity_available{namespace="default",service="cockroachdb-example"})
+        record: node:cockroachdb_capacity_available:sum
+      - expr: |
+          sum without(instance) (node:cockroachdb_capacity_available:sum{namespace="default",service="cockroachdb-example"})
+        record: cluster:cockroachdb_capacity_available:sum
+      - expr: |
+          cockroachdb_capacity_available{namespace="default",service="cockroachdb-example"} / cockroachdb_capacity{namespace="default",service="cockroachdb-example"}
+        record: :cockroachdb_capacity_available:ratio
+      - expr: |
+          node:cockroachdb_capacity_available:sum{namespace="default",service="cockroachdb-example"} / node:cockroachdb_capacity:sum{namespace="default",service="cockroachdb-example"}
+        record: node:cockroachdb_capacity_available:ratio
+      - expr: |
+          cluster:cockroachdb_capacity_available:sum{namespace="default",service="cockroachdb-example"} / cluster:cockroachdb_capacity:sum{namespace="default",service="cockroachdb-example"}
+        record: cluster:cockroachdb_capacity_available:ratio
 - apiVersion: v1
   kind: Service
   metadata:

--- a/examples/pvc/pvc.yaml
+++ b/examples/pvc/pvc.yaml
@@ -42,6 +42,110 @@ items:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: example
         app.kubernetes.io/name: cockroachdb-example
+- apiVersion: monitoring.coreos.com/v1
+  kind: PrometheusRule
+  metadata:
+    labels:
+      app.kubernetes.io/component: database
+      app.kubernetes.io/instance: example
+      app.kubernetes.io/name: cockroachdb-example
+      prometheus: k8s
+      role: alert-rules
+    name: cockroachdb-example
+    namespace: default
+  spec:
+    groups:
+    - name: cockroachdb
+      rules:
+      - alert: CockroachInstanceFlapping
+        annotations:
+          message: '{{ $labels.instance }} for cluster {{ $labels.cluster }} restarted {{ $value }} time(s) in 10m'
+        expr: |
+          resets(cockroachdb_sys_uptime{namespace="default",service="cockroachdb-example"}[10m]) > 5
+        for: 1m
+        labels:
+          severity: warning
+      - alert: CockroachLivenessMismatch
+        annotations:
+          message: Liveness mismatch for {{ $labels.instance }}
+        expr: |
+          (cockroachdb_liveness_livenodes{namespace="default",service="cockroachdb-example"})
+            !=
+          ignoring(instance) group_left() (count by(cluster, job) (up{namespace="default",service="cockroachdb-example"} == 1))
+        for: 5m
+        labels:
+          severity: warning
+      - alert: CockroachVersionMismatch
+        annotations:
+          message: Cluster {{ $labels.cluster }} running {{ $value }} different versions
+        expr: |
+          count by(cluster) (count_values by(tag, cluster) ("version", cockroachdb_build_timestamp{namespace="default",service="cockroachdb-example"})) > 1
+        for: 1h
+        labels:
+          severity: warning
+      - alert: CockroachStoreDiskLow
+        annotations:
+          message: Store {{ $labels.store }} on node {{ $labels.instance }} at {{ $value }} available disk fraction
+        expr: |
+          :cockroachdb_capacity_available:ratio{namespace="default",service="cockroachdb-example"} < 0.15
+        for: 30m
+        labels:
+          severity: critical
+      - alert: CockroachClusterDiskLow
+        annotations:
+          message: Cluster {{ $labels.cluster }} at {{ $value }} available disk fraction
+        expr: |
+          cluster:cockroachdb_capacity_available:ratio{namespace="default",service="cockroachdb-example"} < 0.2
+        for: 30m
+        labels:
+          severity: critical
+      - alert: CockroachUnavailableRanges
+        annotations:
+          message: Instance {{ $labels.instance }} has {{ $value }} unavailable ranges
+        expr: |
+          (sum by(instance, cluster) (cockroachdb_ranges_unavailable{namespace="default",service="cockroachdb-example"})) > 0
+        for: 10m
+        labels:
+          severity: critical
+      - alert: CockroachNoLeaseRanges
+        annotations:
+          message: Instance {{ $labels.instance }} has {{ $value }} ranges without leases
+        expr: |
+          (sum by(instance, cluster) (cockroachdb_replicas_leaders_not_leaseholders{namespace="default",service="cockroachdb-example"})) > 0
+        for: 10m
+        labels:
+          severity: warning
+      - alert: CockroachHighOpenFDCount
+        annotations:
+          message: 'Too many open file descriptors on {{ $labels.instance }}: {{ $value }} fraction used'
+        expr: |
+          cockroachdb_sys_fd_open{namespace="default",service="cockroachdb-example"} / cockroachdb_sys_fd_softlimit{namespace="default",service="cockroachdb-example"} > 0.8
+        for: 10m
+        labels:
+          severity: warning
+    - name: cockroachdb.rules
+      rules:
+      - expr: |
+          sum without(store) (cockroachdb_capacity{namespace="default",service="cockroachdb-example"})
+        record: node:cockroachdb_capacity:sum
+      - expr: |
+          sum without(instance) (node:cockroachdb_capacity:sum{namespace="default",service="cockroachdb-example"})
+        record: cluster:cockroachdb_capacity:sum
+      - expr: |
+          sum without(store) (cockroachdb_capacity_available{namespace="default",service="cockroachdb-example"})
+        record: node:cockroachdb_capacity_available:sum
+      - expr: |
+          sum without(instance) (node:cockroachdb_capacity_available:sum{namespace="default",service="cockroachdb-example"})
+        record: cluster:cockroachdb_capacity_available:sum
+      - expr: |
+          cockroachdb_capacity_available{namespace="default",service="cockroachdb-example"} / cockroachdb_capacity{namespace="default",service="cockroachdb-example"}
+        record: :cockroachdb_capacity_available:ratio
+      - expr: |
+          node:cockroachdb_capacity_available:sum{namespace="default",service="cockroachdb-example"} / node:cockroachdb_capacity:sum{namespace="default",service="cockroachdb-example"}
+        record: node:cockroachdb_capacity_available:ratio
+      - expr: |
+          cluster:cockroachdb_capacity_available:sum{namespace="default",service="cockroachdb-example"} / cluster:cockroachdb_capacity:sum{namespace="default",service="cockroachdb-example"}
+        record: cluster:cockroachdb_capacity_available:ratio
 - apiVersion: v1
   kind: Service
   metadata:

--- a/kubernetes.libsonnet
+++ b/kubernetes.libsonnet
@@ -253,5 +253,30 @@ function(params) {
     },
   },
 
+  prometheusRule: {
+    local monitoring = (import './monitoring/mixin.libsonnet') + {
+      _config+:: {
+        cockroachdbSelector: 'namespace="%s",service="%s"' % [
+          cockroachdb.metadata.namespace,
+          cockroachdb.metadata.name,
+        ],
+      },
+    },
+
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'PrometheusRule',
+    metadata: cockroachdb.metadata {
+      labels+: {
+        prometheus: 'k8s',
+        role: 'alert-rules',
+      },
+    },
+    spec: {
+      groups:
+        monitoring.prometheusAlerts.groups +
+        monitoring.prometheusRules.groups,
+    },
+  },
+
   // TODO: Add backups to object storage via CronJob and Minio
 }

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -5,5 +5,10 @@ COPY ./config.yaml /kube-cockroachdb/operator/config.yaml
 COPY ./main.jsonnet /kube-cockroachdb/operator/main.jsonnet
 COPY ./kubernetes.libsonnet /kube-cockroachdb/operator/kubernetes.libsonnet
 
+COPY ./monitoring/alerts/cockroachdb.libsonnet /kube-cockroachdb/monitoring/alerts/cockroachdb.libsonnet
+COPY ./monitoring/config.libsonnet /kube-cockroachdb/monitoring/config.libsonnet
+COPY ./monitoring/mixin.libsonnet /kube-cockroachdb/monitoring/mixin.libsonnet
+COPY ./monitoring/rules/cockroachdb.libsonnet /kube-cockroachdb/monitoring/rules/cockroachdb.libsonnet
+
 WORKDIR /kube-cockroachdb/operator
 ENTRYPOINT [ "/kube-cockroachdb/operator/operator" ]

--- a/operator/deployment.jsonnet
+++ b/operator/deployment.jsonnet
@@ -54,7 +54,7 @@ local objects = {
       { apiGroups: [''], resources: ['pods/exec'], verbs: ['create'] },
       { apiGroups: ['apps'], resources: ['statefulsets'], verbs: ['list', 'watch', 'get', 'create', 'update'] },
       { apiGroups: ['policy'], resources: ['poddisruptionbudgets'], verbs: ['list', 'watch'] },
-      { apiGroups: ['monitoring.coreos.com'], resources: ['servicemonitors'], verbs: ['list', 'watch', 'get', 'create', 'update'] },
+      { apiGroups: ['monitoring.coreos.com'], resources: ['servicemonitors', 'prometheusrules'], verbs: ['list', 'watch', 'get', 'create', 'update'] },
     ],
   },
   clusterRoleBinding: {

--- a/operator/main.jsonnet
+++ b/operator/main.jsonnet
@@ -90,6 +90,10 @@ local config = import 'generic-operator/config';
               object: 'serviceMonitor',
             },
             {
+              action: 'CreateOrUpdate',
+              object: 'prometheusRule',
+            },
+            {
               action: 'InitializeIfNot',
               object: 'statefulSet',
             },


### PR DESCRIPTION
This will automatically start alerting if a Prometheus is picking it up.

The monitoring mixin in `monitoring/` is now pulled in by the `kubernetes.libsonnet` to generate a PrometheusRule. 
With that we can do the same in the Operator and generate the alerting and recording rules for each cluster on the fly.