### PR TITLE
actions: Disambiguate host

### DIFF
--- a/operator/actions/decommission.go
+++ b/operator/actions/decommission.go
@@ -76,7 +76,7 @@ func (a *DecommissionNodeAction) Execute(rc *client.ResourceClient, u *unstructu
 		return nil
 	}
 
-	command := []string{"cockroach", "node", "decommission", "--insecure"}
+	command := []string{"cockroach", "node", "decommission", "--insecure", "--self"}
 	for _, id := range decommissionIDs {
 		command = append(command, fmt.Sprintf("%d", id))
 	}

--- a/operator/actions/recommission.go
+++ b/operator/actions/recommission.go
@@ -59,7 +59,7 @@ func (a *RecommissionNodeAction) Execute(rc *client.ResourceClient, u *unstructu
 
 	start := time.Now()
 
-	command := []string{"cockroach", "node", "recommission", "--insecure"}
+	command := []string{"cockroach", "node", "recommission", "--insecure", "--self"}
 	level.Debug(a.Logger).Log("msg", "recommissioning nodes", "command", strings.Join(command, " "))
 	for _, id := range recommissionIDs {
 		command = append(command, fmt.Sprintf("%d", id))


### PR DESCRIPTION
Newer versions of cockroachdb want the host to be non-ambiguous, or rather not implicit.