### PR TITLE
Add Dockerfile that doesn't require it to be run by drone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.17-alpine AS build
+
+ARG ARCH=amd64
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=$ARCH
+
+RUN mkdir /app && apk add --no-cache make
+WORKDIR /app
+COPY . /app
+
+RUN make build -o operator/api/v1alphav1/zz_generated.deepcopy.go
+RUN cp ./kubernetes.libsonnet ./operator/kubernetes.libsonnet
+
+FROM alpine:3.11
+
+COPY --from=build /app/operator/operator /kube-cockroachdb/operator/operator
+COPY --from=build /app/operator/config.yaml /kube-cockroachdb/operator/config.yaml
+COPY --from=build /app/operator/main.jsonnet /kube-cockroachdb/operator/main.jsonnet
+COPY --from=build /app/operator/kubernetes.libsonnet /kube-cockroachdb/operator/kubernetes.libsonnet
+
+WORKDIR /kube-cockroachdb/operator
+ENTRYPOINT [ "/kube-cockroachdb/operator/operator" ]

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,9 +1,0 @@
-FROM alpine:3.11
-
-COPY ./operator /kube-cockroachdb/operator/operator
-COPY ./config.yaml /kube-cockroachdb/operator/config.yaml
-COPY ./main.jsonnet /kube-cockroachdb/operator/main.jsonnet
-COPY ./kubernetes.libsonnet /kube-cockroachdb/operator/kubernetes.libsonnet
-
-WORKDIR /kube-cockroachdb/operator
-ENTRYPOINT [ "/kube-cockroachdb/operator/operator" ]


### PR DESCRIPTION
This might be a bit controversial, but I think the way that building containers worked on drone is not great, since it was hiding a lot of the mechanics of how to build an image locally. This is the dockerfile I used after some tinkering that worked well.

I'd suggest to move the repo over to github actions. Happy to do that move.